### PR TITLE
Fix Supabase config parsing

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,5 +1,4 @@
 # A string used as a secret key for generating JWT tokens
-jwt_secret = "XqOcXPCuH4mK2ZxXp2iR3jYJEI2m3X4SME9LwRarwp7jm/abAzAfz7ngeWcaqawgWO9d9VUQHFiH5k5l8P8UpQ=="
 project_id = "leznzqfezoofngumpiqf"
 
 [api]
@@ -30,15 +29,15 @@ port = 54323
 api_url = "http://localhost"
 
 # Enable PWA Edge Functions
+
 [functions]
-enabled = true
-port = 54324
 
 [storage]
 enabled = true
 
 [auth]
 enabled = true
+jwt_secret = "XqOcXPCuH4mK2ZxXp2iR3jYJEI2m3X4SME9LwRarwp7jm/abAzAfz7ngeWcaqawgWO9d9VUQHFiH5k5l8P8UpQ=="
 
 [analytics]
 enabled = false


### PR DESCRIPTION
## Summary
- move `jwt_secret` under `[auth]`
- drop unused global `functions` settings

## Testing
- `npm run lint` *(fails: Invalid option '--report-unused-directives')*