### PR TITLE
Fix PWA manifest icon paths

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,44 +10,9 @@
   "start_url": "/",
   "icons": [
     {
-      "src": "icons/icon-72x72.png",
-      "sizes": "72x72",
-      "type": "image/png"
-    },
-    {
-      "src": "icons/icon-96x96.png",
-      "sizes": "96x96",
-      "type": "image/png"
-    },
-    {
-      "src": "icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png"
-    },
-    {
-      "src": "icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png"
-    },
-    {
-      "src": "icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png"
-    },
-    {
-      "src": "icons/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "icons/icon-384x384.png",
-      "sizes": "384x384",
-      "type": "image/png"
-    },
-    {
-      "src": "icons/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
+      "src": "https://leznzqfezoofngumpiqf.supabase.co/storage/v1/object/sign/logos/favicon.svg?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InN0b3JhZ2UtdXJsLXNpZ25pbmcta2V5X2UyYTcyNGEyLTZkNTctNDk4YS04ZGU1LWY2Y2Q4MjAyNjA3YiJ9.eyJ1cmwiOiJsb2dvcy9mYXZpY29uLnN2ZyIsImlhdCI6MTc0NzI5OTE1NywiZXhwIjoxNzc4ODM1MTU3fQ.rOddcgsmXrPC8bqm0vvWl_3VWveHtI2ybGSLS1tpxJg",
+      "sizes": "any",
+      "type": "image/svg+xml",
       "purpose": "any maskable"
     }
   ]


### PR DESCRIPTION
## Summary
- update `public/manifest.json` to point to an existing remote icon

## Testing
- `npm run lint` *(fails: Invalid option '--report-unused-directives')*