### PR TITLE
Fix Netlify build by skipping submodules

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,5 @@
 
 [build.environment]
   NODE_VERSION = "18"
+  # Skip submodule processing since this repo does not use submodules
+  GIT_SUBMODULE_STRATEGY = "none"


### PR DESCRIPTION
## Summary
- skip git submodule processing on Netlify so the build won't fail if an empty submodule path exists

## Testing
- `git status --short`