### PR TITLE
Add DB connection test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,24 @@ cd biowell-ai
 npm install
 ```
 
-3. Create a `.env` file based on `.env.example` and add your Supabase credentials:
+3. Create a `.env` file based on `.env.example` and add your Supabase credentials.
+   Include a `DATABASE_URL` variable pointing to your Postgres connection string if
+   you want to test a direct database connection:
 
 ```
 VITE_SUPABASE_URL=your-supabase-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 VITE_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key
+DATABASE_URL=postgresql://postgres:your-password@db.example.supabase.co:5432/postgres
 ```
 
-4. Start the development server:
+4. Verify the database connection (optional):
+
+```bash
+npm run test:db
+```
+
+5. Start the development server:
 
 ```bash
 npm run dev

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-directives --max-warnings 0",
     "preview": "vite preview",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test:db": "node scripts/test-db-connection.js"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.0.16",
@@ -25,7 +26,8 @@
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.21.1",
     "tailwind-merge": "^3.2.0",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "pg": "^8.11.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",

--- a/scripts/test-db-connection.js
+++ b/scripts/test-db-connection.js
@@ -1,0 +1,26 @@
+import { Client } from 'pg';
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  console.error('DATABASE_URL environment variable is not set');
+  process.exit(1);
+}
+
+const client = new Client({
+  connectionString,
+});
+
+async function testConnection() {
+  try {
+    await client.connect();
+    const res = await client.query('SELECT 1 as result');
+    console.log('Connection successful:', res.rows[0].result === 1);
+  } catch (err) {
+    console.error('Failed to connect:', err.message);
+  } finally {
+    await client.end();
+  }
+}
+
+testConnection();


### PR DESCRIPTION
## Summary
- add a simple Node script to verify the `DATABASE_URL`
- document how to use the script in README
- register `test:db` npm script and include `pg` dependency

## Testing
- `npm run lint` *(fails: Invalid option '--report-unused-directives')*