### PR TITLE
Improve session refresh handling

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -183,6 +183,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Function to refresh the session
   const refreshSession = async () => {
     try {
+      const { data: current } = await supabase.auth.getSession();
+
+      // If no valid refresh token exists, skip the refresh attempt
+      if (!current.session?.refresh_token) {
+        console.warn('No refresh token available, skipping refresh');
+        return;
+      }
+
       const { data, error } = await supabase.auth.refreshSession();
       
       if (error) {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -39,6 +39,14 @@ supabase.auth.onAuthStateChange((event, session) => {
   if (event === 'TOKEN_REFRESHED') {
     console.log('Token refreshed successfully');
   }
+
+  if (event === 'TOKEN_REFRESH_FAILED') {
+    console.warn('Token refresh failed, signing out');
+    supabase.auth
+      .signOut()
+      .catch((err) => console.error('Error during sign out:', err));
+    localStorage.removeItem('biowell-user-data');
+  }
   
   if (event === 'SIGNED_OUT') {
     console.log('User signed out');

--- a/src/utils/authHelpers.ts
+++ b/src/utils/authHelpers.ts
@@ -26,7 +26,12 @@ export async function validateSession(): Promise<boolean> {
     
     if (expiresAt && expiresAt - now < 300) {
       console.log('Session expiring soon, refreshing...');
-      
+
+      if (!session.refresh_token) {
+        console.warn('No refresh token available, skipping refresh');
+        return false;
+      }
+
       // Try to refresh the session
       const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession();
       


### PR DESCRIPTION
## Summary
- handle missing refresh token gracefully when refreshing session
- auto sign out if token refresh fails

## Testing
- `npm run lint` *(fails: Invalid option '--report-unused-directives')*
- `npm run build` *(fails: vite not found)*