### PR TITLE
Add centralized error logging

### DIFF
--- a/src/components/auth/AuthErrorHandler.tsx
+++ b/src/components/auth/AuthErrorHandler.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 
 /**
  * Component to handle authentication errors globally
@@ -22,19 +23,19 @@ const AuthErrorHandler = () => {
           if (response.status === 400 && 
               (errorData.error?.includes('Invalid Refresh Token') || 
                errorData.error?.includes('Refresh Token Not Found'))) {
-            console.error('Auth error detected:', errorData.error);
+            logError('Auth error detected', errorData.error);
             
             // Try to refresh the session
             try {
               await refreshSession();
             } catch (refreshError) {
               // If refresh fails, redirect to login
-              console.error('Session refresh failed:', refreshError);
+              logError('Session refresh failed', refreshError);
               navigate('/login', { replace: true });
             }
           }
         } catch (parseError) {
-          console.error('Error parsing API response:', parseError);
+          logError('Error parsing API response', parseError);
         }
       }
     };

--- a/src/components/chat/AIHealthCoach.tsx
+++ b/src/components/chat/AIHealthCoach.tsx
@@ -4,6 +4,7 @@ import { Send, Loader, AlertCircle, Info, User } from 'lucide-react';
 import { useChatApi } from '../../hooks/useChatApi';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
+import { logError } from '../../utils/logger';
 import ReactMarkdown from 'react-markdown';
 
 interface Message {
@@ -92,7 +93,7 @@ export default function HealthCoach() {
         ]);
       }
     } catch (err: any) {
-      console.error("Error in chat submission:", err);
+      logError('Error in chat submission', err);
       setError(err.message || "Failed to get a response. Please try again.");
     }
   };

--- a/src/components/chat/ActionFetchBlock.tsx
+++ b/src/components/chat/ActionFetchBlock.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 
 interface ActionFetchBlockProps {
   id: string;
@@ -55,7 +56,7 @@ const ActionFetchBlock = ({
       setAiResponse(data.response || data.message || JSON.stringify(data));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
-      console.error('Fetch error:', err);
+      logError('Fetch error', err);
     } finally {
       setLoading(false);
     }

--- a/src/components/chat/ChatButton.tsx
+++ b/src/components/chat/ChatButton.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useChatApi } from '../../hooks/useChatApi';
 import { useAuth } from '../../contexts/AuthContext';
 import { Loader, AlertCircle } from 'lucide-react';
+import { logError } from '../../utils/logger';
 
 export default function ChatButton() {
   const [loading, setLoading] = useState(false);
@@ -22,7 +23,7 @@ export default function ChatButton() {
       const reply = await sendMessage(messages, userId);
       setResponse(reply || 'No response received.');
     } catch (err) {
-      console.error('Error in chat:', err);
+      logError('Error in chat', err);
       setResponse('Failed to fetch assistant reply.');
     } finally {
       setLoading(false);

--- a/src/components/chat/CoachChat.tsx
+++ b/src/components/chat/CoachChat.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Send, Loader, AlertCircle, MessageCircle } from 'lucide-react';
 import { useChatApi } from '../../hooks/useChatApi';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 
 export default function CoachChat() {
   const [input, setInput] = useState('');
@@ -26,8 +27,8 @@ export default function CoachChat() {
       const content = await sendMessage(messages, userId);
       setResponse(content);
     } catch (err: any) {
-      setError(err.message || "Failed to fetch");
-      console.error("Chat error:", err);
+      setError(err.message || 'Failed to fetch');
+      logError('Chat error', err);
     } finally {
       setLoading(false);
     }

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle } from 'lucide-react';
+import { logError } from '../../utils/logger';
 
 interface Props {
   children: ReactNode;
@@ -21,7 +22,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Uncaught error:', error, errorInfo);
+    logError('Uncaught error', error, { errorInfo });
   }
 
   public render() {

--- a/src/components/common/PricingSection.tsx
+++ b/src/components/common/PricingSection.tsx
@@ -4,6 +4,7 @@ import { Check, Shield, ArrowRight, CreditCard, Building, User } from 'lucide-re
 import { Link } from 'react-router-dom';
 import { useSupabase } from '../../contexts/SupabaseContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 
 interface Plan {
   id: string;
@@ -121,7 +122,7 @@ const PricingSection = () => {
       
       console.log(`Added plan ${planId} to cart with annual billing: ${isAnnual}`);
     } catch (error) {
-      console.error('Error adding plan to cart:', error);
+      logError('Error adding plan to cart', error);
     }
   };
 
@@ -166,7 +167,7 @@ const PricingSection = () => {
       // Show success message or redirect to success page
       alert('Your subscription has been processed successfully!');
     } catch (error) {
-      console.error('Error processing payment:', error);
+      logError('Error processing payment', error);
       alert('There was an error processing your payment. Please try again.');
     } finally {
       setLoading(false);

--- a/src/components/dashboard/DeploymentStatusWidget.tsx
+++ b/src/components/dashboard/DeploymentStatusWidget.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Rocket, ExternalLink } from 'lucide-react';
 import { checkDeploymentStatus, DeploymentInfo } from '../../utils/deploymentStatus';
+import { logError } from '../../utils/logger';
 
 const DeploymentStatusWidget = () => {
   const [deploymentInfo, setDeploymentInfo] = useState<DeploymentInfo | null>(null);
@@ -13,7 +14,7 @@ const DeploymentStatusWidget = () => {
         const status = await checkDeploymentStatus();
         setDeploymentInfo(status);
       } catch (error) {
-        console.error('Error fetching deployment status:', error);
+        logError('Error fetching deployment status', error);
       } finally {
         setLoading(false);
       }

--- a/src/components/dashboard/DeviceDropdown.tsx
+++ b/src/components/dashboard/DeviceDropdown.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSupabase } from '../../contexts/SupabaseContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 import { Watch, ChevronDown, ChevronUp, Plus, Check, Loader, AlertCircle } from 'lucide-react';
 import { getDeviceImage } from '../../utils/deviceImages';
 import ImageWithFallback from '../common/ImageWithFallback';
@@ -87,7 +88,7 @@ const DeviceDropdown = () => {
           })));
         }
       } catch (error) {
-        console.error('Error fetching connected devices:', error);
+        logError('Error fetching connected devices', error);
       }
     };
     
@@ -130,7 +131,7 @@ const DeviceDropdown = () => {
         setSuccessMessage(`Successfully connected to ${devices.find(d => d.id === deviceId)?.name}`);
       }
     } catch (error) {
-      console.error('Error connecting device:', error);
+      logError('Error connecting device', error);
       setErrorMessage(`Failed to connect to ${devices.find(d => d.id === deviceId)?.name}. Please try again.`);
     } finally {
       setConnecting(null);
@@ -168,7 +169,7 @@ const DeviceDropdown = () => {
         setSuccessMessage(`Successfully disconnected from ${devices.find(d => d.id === deviceId)?.name}`);
       }
     } catch (error) {
-      console.error('Error disconnecting device:', error);
+      logError('Error disconnecting device', error);
       setErrorMessage(`Failed to disconnect from ${devices.find(d => d.id === deviceId)?.name}. Please try again.`);
     } finally {
       setConnecting(null);

--- a/src/components/dashboard/HealthTrends.tsx
+++ b/src/components/dashboard/HealthTrends.tsx
@@ -124,7 +124,7 @@ const HealthTrends = ({ userId }: HealthTrendsProps) => {
         const demoData = generateDemoGlucoseData(timeRange);
         processGlucoseData(demoData);
       } catch (error) {
-        console.error('Error fetching glucose data:', error);
+        logError('Error fetching glucose data', error);
         // Fallback to demo data on error
         const demoData = generateDemoGlucoseData(timeRange);
         processGlucoseData(demoData);

--- a/src/components/dashboard/RecentChats.tsx
+++ b/src/components/dashboard/RecentChats.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSupabase } from '../../contexts/SupabaseContext';
+import { logError } from '../../utils/logger';
 import { MessageCircle, ArrowRight, ChevronDown, ChevronUp } from 'lucide-react';
 
 interface RecentChatsProps {
@@ -28,7 +29,7 @@ const RecentChats = ({ userId }: RecentChatsProps) => {
         if (error) throw error;
         setChatHistory(data || []);
       } catch (error) {
-        console.error('Error fetching chat history:', error);
+        logError('Error fetching chat history', error);
         
         // Mock data for demo
         setChatHistory([

--- a/src/components/dashboard/SupplementRecommendations.tsx
+++ b/src/components/dashboard/SupplementRecommendations.tsx
@@ -4,6 +4,7 @@ import { useSupabase } from '../../contexts/SupabaseContext';
 import { Package, ChevronDown, ChevronUp, Plus, Check, AlertCircle } from 'lucide-react';
 import ImageWithFallback from '../common/ImageWithFallback';
 import { getSupplementFormImage } from '../../utils/supplementForms';
+import { logError } from '../../utils/logger';
 
 interface SupplementRecommendationsProps {
   userId: string;
@@ -42,7 +43,7 @@ const SupplementRecommendations = ({ userId }: SupplementRecommendationsProps) =
       setSupplements(suppData || []);
       setUserSupplements(userSuppData?.map(us => us.supplement_id) || []);
     } catch (error) {
-      console.error('Error fetching supplements:', error);
+      logError('Error fetching supplements', error);
       
       // Fallback data
       setSupplements([
@@ -102,7 +103,7 @@ const SupplementRecommendations = ({ userId }: SupplementRecommendationsProps) =
         setUserSupplements(prev => [...prev, supplementId]);
       }
     } catch (error) {
-      console.error('Error updating subscription:', error);
+      logError('Error updating subscription', error);
     }
   };
 

--- a/src/components/onboarding/ConversationalOnboarding.tsx
+++ b/src/components/onboarding/ConversationalOnboarding.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useSupabase } from '../../contexts/SupabaseContext';
 import { useAuth } from '../../contexts/AuthContext';
 import { Send, User, Loader, CheckCircle, AlertCircle } from 'lucide-react';
+import { logError } from '../../utils/logger';
 
 interface Message {
   role: 'system' | 'user';
@@ -82,7 +83,7 @@ const ConversationalOnboarding = () => {
           .maybeSingle();
         
         if (error) {
-          console.error('Supabase query error:', error);
+          logError('Supabase query error', error);
           setError('Failed to check onboarding status. Please try refreshing the page.');
           return;
         }
@@ -95,7 +96,7 @@ const ConversationalOnboarding = () => {
           navigate('/dashboard');
         }
       } catch (err) {
-        console.error('Error checking onboarding status:', err);
+        logError('Error checking onboarding status', err);
         setError('Failed to check onboarding status. Please try refreshing the page.');
       } finally {
         setLoading(false);
@@ -176,7 +177,7 @@ const ConversationalOnboarding = () => {
           addSystemResponse(systemResponse);
       }
     } catch (err) {
-      console.error('Error processing user input:', err);
+      logError('Error processing user input', err);
       setError('Something went wrong. Please try again.');
     } finally {
       setLoading(false);
@@ -288,7 +289,7 @@ const ConversationalOnboarding = () => {
           break;
       }
     } catch (err) {
-      console.error('Error handling button click:', err);
+      logError('Error handling button click', err);
       setError('Something went wrong. Please try again.');
     } finally {
       setLoading(false);
@@ -376,7 +377,7 @@ const ConversationalOnboarding = () => {
         navigate('/dashboard');
       }, 3000);
     } catch (err) {
-      console.error('Error saving onboarding data:', err);
+      logError('Error saving onboarding data', err);
       throw err;
     }
   };

--- a/src/components/supplements/CheckoutForm.tsx
+++ b/src/components/supplements/CheckoutForm.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { ChevronRight, CreditCard, Truck, ShoppingBag, Check, Shield, ArrowLeft } from 'lucide-react';
 import { Supplement } from '../../types/supplements';
 import ImageWithFallback from '../common/ImageWithFallback';
+import { logError } from '../../utils/logger';
 
 interface CartItem {
   supplement: Supplement;
@@ -68,7 +69,7 @@ const CheckoutForm = ({ cartItems, onCheckoutComplete, onBack }: CheckoutFormPro
       alert('Order placed successfully! Thank you for your purchase.');
       onCheckoutComplete();
     } catch (error) {
-      console.error('Error placing order:', error);
+      logError('Error placing order', error);
       alert('There was an error processing your order. Please try again.');
     } finally {
       setLoading(false);

--- a/src/components/supplements/StackBuilder.tsx
+++ b/src/components/supplements/StackBuilder.tsx
@@ -5,6 +5,7 @@ import { useSupabase } from '../../contexts/SupabaseContext';
 import { useAuth } from '../../contexts/AuthContext';
 import { Supplement } from '../../types/supplements';
 import ImageWithFallback from '../common/ImageWithFallback';
+import { logError } from '../../utils/logger';
 
 interface StackBuilderProps {
   supplements: Supplement[];
@@ -70,7 +71,7 @@ const StackBuilder = ({ supplements, userSupplements, onToggleSubscription }: St
       
       setActiveStack('sleep-stack');
     } catch (error) {
-      console.error('Error fetching stacks:', error);
+      logError('Error fetching stacks', error);
       setError('Failed to load your supplement stacks');
     } finally {
       setLoading(false);
@@ -107,7 +108,7 @@ const StackBuilder = ({ supplements, userSupplements, onToggleSubscription }: St
       // Clear success message after 3 seconds
       setTimeout(() => setSuccess(null), 3000);
     } catch (error) {
-      console.error('Error creating stack:', error);
+      logError('Error creating stack', error);
       setError('Failed to create stack');
     } finally {
       setLoading(false);
@@ -142,7 +143,7 @@ const StackBuilder = ({ supplements, userSupplements, onToggleSubscription }: St
       // Clear success message after 3 seconds
       setTimeout(() => setSuccess(null), 3000);
     } catch (error) {
-      console.error('Error activating stack:', error);
+      logError('Error activating stack', error);
       setError('Failed to activate stack');
     } finally {
       setLoading(false);
@@ -166,7 +167,7 @@ const StackBuilder = ({ supplements, userSupplements, onToggleSubscription }: St
       // Clear success message after 3 seconds
       setTimeout(() => setSuccess(null), 3000);
     } catch (error) {
-      console.error('Error deleting stack:', error);
+      logError('Error deleting stack', error);
       setError('Failed to delete stack');
     } finally {
       setLoading(false);

--- a/src/components/supplements/SupplementList.tsx
+++ b/src/components/supplements/SupplementList.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSupabase } from '../../contexts/SupabaseContext';
+import { logError } from '../../utils/logger';
 import { motion } from 'framer-motion';
 import { Search } from 'lucide-react';
 import SupplementCard from './SupplementCard';
@@ -35,7 +36,7 @@ const SupplementList = () => {
       if (userSupplementsError) throw userSupplementsError;
       setUserSupplements(userSupplementsData?.map(us => us.supplement_id) || []);
     } catch (error) {
-      console.error('Error fetching supplements:', error);
+      logError('Error fetching supplements', error);
     } finally {
       setLoading(false);
     }
@@ -60,7 +61,7 @@ const SupplementList = () => {
         setUserSupplements(prev => [...prev, supplementId]);
       }
     } catch (error) {
-      console.error('Error updating subscription:', error);
+      logError('Error updating subscription', error);
     }
   };
 

--- a/src/components/supplements/SupplementRecommender.tsx
+++ b/src/components/supplements/SupplementRecommender.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useOpenAi } from '../../hooks/useOpenAi';
 import { useAuth } from '../../contexts/AuthContext';
 import { Loader, AlertCircle } from 'lucide-react';
+import { logError } from '../../utils/logger';
 
 interface SupplementRecommenderProps {
   onRecommendationsReceived?: (recommendations: string) => void;
@@ -31,7 +32,7 @@ const SupplementRecommender = ({ onRecommendationsReceived }: SupplementRecommen
         onRecommendationsReceived(response);
       }
     } catch (err) {
-      console.error('Error getting recommendations:', err);
+      logError('Error getting recommendations', err);
     }
   };
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { logError } from '../utils/logger';
 import { User, Session } from '@supabase/supabase-js';
 import { useSupabase } from './SupabaseContext';
 
@@ -80,7 +81,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         .maybeSingle();
       
       if (error) {
-        console.error('Error checking onboarding status:', error);
+        logError('Error checking onboarding status', error);
         return false;
       }
       
@@ -97,7 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           });
         
         if (insertError) {
-          console.error('Error creating default profile:', insertError);
+          logError('Error creating default profile', insertError);
         }
         return false;
       }
@@ -119,7 +120,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       
       return false;
     } catch (err) {
-      console.error('Unexpected error checking onboarding status:', err);
+      logError('Unexpected error checking onboarding status', err);
       return false;
     }
   };
@@ -156,7 +157,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
       
       if (metadataError) {
-        console.error('Error updating user metadata:', metadataError);
+        logError('Error updating user metadata', metadataError);
       }
       
       // Save to localStorage for future use
@@ -175,7 +176,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       
       return { error: null };
     } catch (err) {
-      console.error('Error updating profile:', err);
+      logError('Error updating profile', err);
       return { error: err };
     }
   };
@@ -194,7 +195,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const { data, error } = await supabase.auth.refreshSession();
       
       if (error) {
-        console.error('Error refreshing session:', error);
+        logError('Error refreshing session', error);
         
         // If the error is about invalid refresh token, clear the session
         if (error.message.includes('Invalid Refresh Token') || 
@@ -215,7 +216,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setSession(data.session);
       setUser(data.session?.user ?? null);
     } catch (err) {
-      console.error('Unexpected error during session refresh:', err);
+      logError('Unexpected error during session refresh', err);
     }
   };
 
@@ -231,7 +232,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const { data, error } = await supabase.auth.getSession();
         
         if (error) {
-          console.error('Error getting session:', error);
+          logError('Error getting session', error);
           setLoading(false);
           return;
         }
@@ -255,7 +256,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           }
         }
       } catch (err) {
-        console.error('Error initializing auth:', err);
+        logError('Error initializing auth', err);
       } finally {
         setLoading(false);
       }
@@ -270,7 +271,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           .maybeSingle();
         
         if (error) {
-          console.error('Error loading user profile:', error);
+          logError('Error loading user profile', error);
           return;
         }
         
@@ -287,7 +288,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           localStorage.setItem('biowell-user-data', JSON.stringify(profileData));
         }
       } catch (err) {
-        console.error('Error loading user profile:', err);
+        logError('Error loading user profile', err);
       }
     };
 
@@ -357,7 +358,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // In production, this would be a real API call to verify the captcha
       return `${captchaSecretKey}-${Date.now()}`;
     } catch (error) {
-      console.error('Error generating captcha token:', error);
+      logError('Error generating captcha token', error);
       return null;
     }
   };
@@ -376,7 +377,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
       
       if (error) {
-        console.error('Sign in error:', error);
+        logError('Sign in error', error);
         return { error };
       }
       
@@ -408,7 +409,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       
       return { error: null };
     } catch (err) {
-      console.error('Unexpected error during sign in:', err);
+      logError('Unexpected error during sign in', err);
       return { error: err };
     }
   };
@@ -427,7 +428,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
       
       if (error) {
-        console.error('Sign up error:', error);
+        logError('Sign up error', error);
         return { data: null, error };
       }
       
@@ -444,13 +445,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           });
         
         if (profileError) {
-          console.error('Error creating default profile:', profileError);
+          logError('Error creating default profile', profileError);
         }
       }
       
       return { data, error: null };
     } catch (err) {
-      console.error('Unexpected error during sign up:', err);
+      logError('Unexpected error during sign up', err);
       return { data: null, error: err };
     }
   };
@@ -460,7 +461,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (!isDemo) {
         const { error } = await supabase.auth.signOut();
         if (error) {
-          console.error('Sign out error:', error);
+          logError('Sign out error', error);
           throw error;
         }
       }
@@ -472,7 +473,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Clear user data from localStorage
       localStorage.removeItem('biowell-user-data');
     } catch (err) {
-      console.error('Unexpected error during sign out:', err);
+      logError('Unexpected error during sign out', err);
       // Even if there's an error, we should still clear the local state
       setIsDemo(false);
       setUser(null);

--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { validateSession } from '../utils/authHelpers';
+import { logError } from '../utils/logger';
 
 /**
  * Hook to guard routes that require authentication
@@ -29,7 +30,7 @@ export function useAuthGuard(redirectTo: string = '/login') {
           // Try to refresh the session
           await refreshSession();
         } catch (error) {
-          console.error('Session refresh failed:', error);
+          logError('Session refresh failed', error);
           navigate(redirectTo, { replace: true });
         }
       }

--- a/src/hooks/useChatApi.ts
+++ b/src/hooks/useChatApi.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { supabase } from "../lib/supabaseClient";
+import { logError } from "../utils/logger";
 
 export function useChatApi() {
   const [loading, setLoading] = useState(false);
@@ -73,7 +74,7 @@ export function useChatApi() {
             errorMessage = errorData.error.message;
           }
         } catch (parseError) {
-          console.error("Error parsing error response:", parseError);
+          logError('Error parsing error response', parseError);
         }
 
         // Handle specific status codes
@@ -92,7 +93,7 @@ export function useChatApi() {
       const data = await response.json();
       return data.choices?.[0]?.message?.content || "";
     } catch (err: any) {
-      console.error("Chat API error:", err);
+      logError('Chat API error', err);
       
       let errorMessage: string;
       if (err.name === 'AbortError') {

--- a/src/hooks/useOpenAi.ts
+++ b/src/hooks/useOpenAi.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { callOpenAiFunction } from '../utils/openai';
+import { logError } from '../utils/logger';
 
 export function useOpenAi() {
   const [loading, setLoading] = useState(false);
@@ -13,8 +14,8 @@ export function useOpenAi() {
       const response = await callOpenAiFunction(prompt, context);
       return response;
     } catch (err) {
-      console.error("OpenAI API error:", err);
-      const errorMessage = err instanceof Error ? err.message : "Failed to generate response";
+      logError('OpenAI API error', err);
+      const errorMessage = err instanceof Error ? err.message : 'Failed to generate response';
       setError(errorMessage);
       throw new Error(errorMessage);
     } finally {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabaseClient';
 import type { User, Session } from '@supabase/supabase-js';
+import { logError } from '../utils/logger';
 
 export interface AuthResponse {
   user: User | null;
@@ -21,7 +22,7 @@ const generateCaptchaToken = async () => {
     // Simulate a captcha verification request
     return `${captchaSecretKey}-${Date.now()}`;
   } catch (error) {
-    console.error('Error generating captcha token:', error);
+    logError('Error generating captcha token', error);
     return null;
   }
 };
@@ -44,14 +45,14 @@ export async function login(email: string, password: string): Promise<AuthRespon
     });
 
     if (error) {
-      console.error('Login error:', error.message);
+      logError('Login error', error.message);
       throw new Error(error.message);
     }
 
     console.log('Login success');
     return data;
   } catch (error) {
-    console.error('Login error:', error);
+    logError('Login error', error);
     throw error;
   }
 }
@@ -77,14 +78,14 @@ export async function signUp(email: string, password: string): Promise<{ data: a
     });
 
     if (error) {
-      console.error('Signup error:', error.message);
+      logError('Signup error', error.message);
       return { data: null, error };
     }
 
     console.log('Signup success');
     return { data, error: null };
   } catch (error) {
-    console.error('Signup error:', error);
+    logError('Signup error', error);
     return { data: null, error };
   }
 }
@@ -97,13 +98,13 @@ export async function signOut(): Promise<void> {
     const { error } = await supabase.auth.signOut();
     
     if (error) {
-      console.error('Signout error:', error.message);
+      logError('Signout error', error.message);
       throw new Error(error.message);
     }
     
     console.log('Signout success');
   } catch (error) {
-    console.error('Signout error:', error);
+    logError('Signout error', error);
     throw error;
   }
 }
@@ -116,13 +117,13 @@ export async function getCurrentSession(): Promise<Session | null> {
     const { data, error } = await supabase.auth.getSession();
     
     if (error) {
-      console.error('Get session error:', error.message);
+      logError('Get session error', error.message);
       throw new Error(error.message);
     }
     
     return data.session;
   } catch (error) {
-    console.error('Get session error:', error);
+    logError('Get session error', error);
     throw error;
   }
 }
@@ -135,7 +136,7 @@ export async function refreshSession(): Promise<Session | null> {
     const { data, error } = await supabase.auth.refreshSession();
     
     if (error) {
-      console.error('Refresh session error:', error.message);
+      logError('Refresh session error', error.message);
       
       // If the error is about invalid refresh token, clear the session
       if (error.message.includes('Invalid Refresh Token') || 
@@ -149,7 +150,7 @@ export async function refreshSession(): Promise<Session | null> {
     
     return data.session;
   } catch (error) {
-    console.error('Refresh session error:', error);
+    logError('Refresh session error', error);
     throw error;
   }
 }
@@ -162,13 +163,13 @@ export async function getCurrentUser(): Promise<User | null> {
     const { data, error } = await supabase.auth.getUser();
     
     if (error) {
-      console.error('Get user error:', error.message);
+      logError('Get user error', error.message);
       throw new Error(error.message);
     }
     
     return data.user;
   } catch (error) {
-    console.error('Get user error:', error);
+    logError('Get user error', error);
     throw error;
   }
 }
@@ -183,13 +184,13 @@ export async function resetPassword(email: string): Promise<void> {
     });
     
     if (error) {
-      console.error('Reset password error:', error.message);
+      logError('Reset password error', error.message);
       throw new Error(error.message);
     }
     
     console.log('Reset password email sent');
   } catch (error) {
-    console.error('Reset password error:', error);
+    logError('Reset password error', error);
     throw error;
   }
 }
@@ -204,13 +205,13 @@ export async function updatePassword(password: string): Promise<void> {
     });
     
     if (error) {
-      console.error('Update password error:', error.message);
+      logError('Update password error', error.message);
       throw new Error(error.message);
     }
     
     console.log('Password updated successfully');
   } catch (error) {
-    console.error('Update password error:', error);
+    logError('Update password error', error);
     throw error;
   }
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { logError } from '../utils/logger';
 
 // Get environment variables
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
@@ -26,7 +27,7 @@ export const supabase = createClient(
     global: {
       fetch: (...args) => {
         return fetch(...args).catch(err => {
-          console.error('Supabase fetch error:', err);
+          logError('Supabase fetch error', err);
           throw err;
         });
       }
@@ -44,7 +45,7 @@ supabase.auth.onAuthStateChange((event, session) => {
     console.warn('Token refresh failed, signing out');
     supabase.auth
       .signOut()
-      .catch((err) => console.error('Error during sign out:', err));
+      .catch((err) => logError('Error during sign out', err));
     localStorage.removeItem('biowell-user-data');
   }
   

--- a/src/pages/auth/OnboardingPage.tsx
+++ b/src/pages/auth/OnboardingPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useSupabase } from '../../contexts/SupabaseContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 import OnboardingForm from '../../components/auth/OnboardingForm';
 import ConversationalOnboarding from '../../components/onboarding/ConversationalOnboarding';
 import { AlertCircle, CheckCircle } from 'lucide-react';
@@ -32,7 +33,7 @@ const OnboardingPage = () => {
           navigate('/dashboard');
         }
       } catch (err) {
-        console.error('Error checking onboarding status:', err);
+        logError('Error checking onboarding status', err);
         setError('Error checking onboarding status. Please try again.');
       }
     };
@@ -93,7 +94,7 @@ const OnboardingPage = () => {
           });
         
         if (quizError) {
-          console.error('Error saving quiz responses:', quizError);
+          logError('Error saving quiz responses', quizError);
           // Continue even if quiz responses fail
         }
       }
@@ -111,7 +112,7 @@ const OnboardingPage = () => {
       });
       
       if (metadataError) {
-        console.error('Error updating user metadata:', metadataError);
+        logError('Error updating user metadata', metadataError);
         // Continue even if metadata update fails
       }
       
@@ -148,7 +149,7 @@ const OnboardingPage = () => {
         navigate('/dashboard');
       }, 2000);
     } catch (err: any) {
-      console.error('Error completing onboarding:', err);
+      logError('Error completing onboarding', err);
       setError(err.message || 'An error occurred during onboarding');
     } finally {
       setLoading(false);

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { logError } from '../../utils/logger';
 import { motion } from 'framer-motion';
 import { ChevronRight, CreditCard, Truck, ShoppingBag, Check, Shield, ArrowLeft } from 'lucide-react';
 import { Supplement } from '../../types/supplements';
@@ -42,7 +43,7 @@ const CheckoutPage = () => {
       try {
         setCartItems(JSON.parse(savedCart));
       } catch (err) {
-        console.error('Error loading cart from localStorage:', err);
+        logError('Error loading cart from localStorage', err);
       }
     }
   }, []);
@@ -80,7 +81,7 @@ const CheckoutPage = () => {
       alert('Order placed successfully! Thank you for your purchase.');
       navigate('/supplements');
     } catch (error) {
-      console.error('Error placing order:', error);
+      logError('Error placing order', error);
       alert('There was an error processing your order. Please try again.');
     } finally {
       setLoading(false);

--- a/src/pages/dashboard/components/HealthTrends.tsx
+++ b/src/pages/dashboard/components/HealthTrends.tsx
@@ -13,6 +13,7 @@ import {
 import { Line } from 'react-chartjs-2';
 import { useSupabase } from '../../../contexts/SupabaseContext';
 import { useAuth } from '../../../contexts/AuthContext';
+import { logError } from '../../../utils/logger';
 
 ChartJS.register(
   CategoryScale,
@@ -99,7 +100,7 @@ const HealthTrends = ({ userId }: HealthTrendsProps) => {
         
         setChartData(chartData);
       } catch (error) {
-        console.error('Error fetching trend data:', error);
+        logError('Error fetching trend data', error);
       } finally {
         setLoading(false);
       }

--- a/src/pages/dashboard/components/SupplementRecommendations.tsx
+++ b/src/pages/dashboard/components/SupplementRecommendations.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSupabase } from '../../../contexts/SupabaseContext';
+import { logError } from '../../../utils/logger';
 import { ShoppingCart, Pill, AlertCircle, CheckCircle, ArrowRight } from 'lucide-react';
 
 interface SupplementRecommendationsProps {
@@ -39,7 +40,7 @@ const SupplementRecommendations = ({ userId }: SupplementRecommendationsProps) =
         setSupplements(suppData || []);
         setUserSupplements(userSuppData?.map((item) => item.supplement_id) || []);
       } catch (error) {
-        console.error('Error fetching supplements:', error);
+        logError('Error fetching supplements', error);
         
         // Mock data for demo
         setSupplements([
@@ -107,7 +108,7 @@ const SupplementRecommendations = ({ userId }: SupplementRecommendationsProps) =
         setUserSupplements([...userSupplements, supplementId]);
       }
     } catch (error) {
-      console.error('Error toggling subscription:', error);
+      logError('Error toggling subscription', error);
       
       // For demo, just toggle the state
       if (isSubscribed) {

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSupabase } from '../../contexts/SupabaseContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 import { CheckCircle, AlertCircle, Sun, Moon, Laptop } from 'lucide-react';
 import ThemeStatus from '../../components/ThemeStatus';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -55,7 +56,7 @@ const ProfilePage = () => {
           .maybeSingle();
         
         if (error) {
-          console.error('Error loading user profile:', error);
+          logError('Error loading user profile', error);
           return;
         }
         
@@ -73,7 +74,7 @@ const ProfilePage = () => {
           }));
         }
       } catch (error) {
-        console.error('Error fetching profile:', error);
+        logError('Error fetching profile', error);
       } finally {
         setLoading(false);
       }
@@ -116,7 +117,7 @@ const ProfilePage = () => {
       });
       
       if (metadataError) {
-        console.error('Error updating user metadata:', metadataError);
+        logError('Error updating user metadata', metadataError);
       }
       
       // Update localStorage
@@ -130,7 +131,7 @@ const ProfilePage = () => {
       setMessage({ type: 'success', text: 'Profile updated successfully' });
       navigate('/dashboard');
     } catch (error) {
-      console.error('Error updating profile:', error);
+      logError('Error updating profile', error);
       setMessage({ type: 'error', text: 'Failed to update profile' });
     } finally {
       setUpdating(false);

--- a/src/pages/supplements/SupplementsPage.tsx
+++ b/src/pages/supplements/SupplementsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSupabase } from '../../contexts/SupabaseContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { logError } from '../../utils/logger';
 import { motion } from 'framer-motion';
 import { Search, ShoppingCart } from 'lucide-react';
 import SupplementCard from '../../components/supplements/SupplementCard';
@@ -66,7 +67,7 @@ const SupplementsPage = () => {
       try {
         setCartItems(JSON.parse(savedCart));
       } catch (err) {
-        console.error('Error loading cart from localStorage:', err);
+        logError('Error loading cart from localStorage', err);
       }
     }
   }, [user]);
@@ -85,7 +86,7 @@ const SupplementsPage = () => {
       if (error) throw error;
       setSupplements(data || []);
     } catch (err) {
-      console.error('Error fetching supplements:', err);
+      logError('Error fetching supplements', err);
     } finally {
       setLoading(false);
     }
@@ -100,7 +101,7 @@ const SupplementsPage = () => {
       if (error) throw error;
       setStacks(data || []);
     } catch (err) {
-      console.error('Error fetching supplement stacks:', err);
+      logError('Error fetching supplement stacks', err);
     }
   };
 
@@ -114,7 +115,7 @@ const SupplementsPage = () => {
       if (error) throw error;
       setUserSupplements(data?.map(us => us.supplement_id) || []);
     } catch (err) {
-      console.error('Error fetching user supplements:', err);
+      logError('Error fetching user supplements', err);
     }
   };
 
@@ -145,7 +146,7 @@ const SupplementsPage = () => {
         setUserSupplements(prev => [...prev, supplementId]);
       }
     } catch (err) {
-      console.error('Error updating subscription:', err);
+      logError('Error updating subscription', err);
     }
   };
 

--- a/src/utils/authHelpers.ts
+++ b/src/utils/authHelpers.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabase';
+import { logError } from './logger';
 
 /**
  * Checks if the current session is valid and refreshes it if needed
@@ -10,7 +11,7 @@ export async function validateSession(): Promise<boolean> {
     const { data: { session }, error: sessionError } = await supabase.auth.getSession();
     
     if (sessionError) {
-      console.error('Error getting session:', sessionError);
+      logError('Error getting session', sessionError);
       return false;
     }
     
@@ -36,7 +37,7 @@ export async function validateSession(): Promise<boolean> {
       const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession();
       
       if (refreshError) {
-        console.error('Error refreshing session:', refreshError);
+        logError('Error refreshing session', refreshError);
         
         // If the error is about invalid refresh token, clear the session
         if (refreshError.message.includes('Invalid Refresh Token') || 
@@ -55,7 +56,7 @@ export async function validateSession(): Promise<boolean> {
     // Session is valid and not expiring soon
     return true;
   } catch (error) {
-    console.error('Error validating session:', error);
+    logError('Error validating session', error);
     return false;
   }
 }
@@ -69,7 +70,7 @@ export async function handleAuthError(error: any): Promise<void> {
   if (!error) return;
   
   const errorMessage = error.message || error.toString();
-  console.error('Auth error:', errorMessage);
+  logError('Auth error', errorMessage);
   
   // Handle specific auth errors
   if (errorMessage.includes('Invalid Refresh Token') || 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,18 @@
+export interface ErrorContext {
+  [key: string]: unknown;
+}
+
+/**
+ * Logs detailed error information with optional context.
+ * @param message Description of the error context
+ * @param error The error object or value
+ * @param context Additional contextual information
+ */
+export function logError(message: string, error: unknown, context: ErrorContext = {}): void {
+  const timestamp = new Date().toISOString();
+  if (error instanceof Error) {
+    console.error(`[${timestamp}] ${message}`, { message: error.message, stack: error.stack, ...context });
+  } else {
+    console.error(`[${timestamp}] ${message}`, { error, ...context });
+  }
+}

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabaseClient';
+import { logError } from './logger';
 
 export interface ChatMessage {
   role: 'user' | 'assistant';
@@ -58,7 +59,7 @@ export async function callOpenAiFunction(prompt: string, context?: Record<string
       const data = await response.json();
       return data.choices?.[0]?.message?.content || "No response received.";
     } catch (error) {
-      console.error(`Attempt ${retries + 1} failed:`, error);
+      logError(`Attempt ${retries + 1} failed`, error);
       lastError = error instanceof Error ? error : new Error('Unknown error occurred');
       
       // If we get a 429 (rate limit) error, wait and retry
@@ -91,7 +92,7 @@ export async function sendChatMessage(message: string, userId?: string, context?
           response: content
         });
       } catch (error) {
-        console.error("Failed to store chat history:", error);
+        logError('Failed to store chat history', error, { userId });
       }
     }
     
@@ -101,7 +102,7 @@ export async function sendChatMessage(message: string, userId?: string, context?
       timestamp: new Date(),
     };
   } catch (error) {
-    console.error("Error in chat message:", error);
+    logError('Error in chat message', error);
     throw error;
   }
 }

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,11 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
+import { logError } from './logger';
 
 // Get environment variables
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  console.error('Missing Supabase environment variables. Check your .env file.');
+  logError('Missing Supabase environment variables', {});
 }
 
 // Create a single Supabase client instance to use throughout the app


### PR DESCRIPTION
## Summary
- implement a reusable `logError` helper
- use `logError` throughout the app for better diagnostics

## Testing
- `npm run lint` *(fails: Invalid option `--ext`)*