### PR TITLE
Add production env template

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,9 @@
+# Production environment variables for Biowell AI
+# Supply your own values in .env.production (gitignored)
+
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+VITE_OPENAI_API_KEY=
+VITE_GOOGLE_CLIENT_ID=
+VITE_CAPTCHA_SECRET_KEY=
+VITE_STRIPE_PUBLISHABLE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ dist-ssr
 # Environment variables
 .env
 .env.*
+!.env.production.example
+.env.production
 .env.example
 
 # Supabase

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 VITE_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key
 ```
 
-4. Start the development server:
+4. For production builds, copy `.env.production.example` to `.env.production` and add your production values. This file is ignored by Git.
+
+5. Start the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Summary
- ignore `.env.production`
- add example production env file
- document how to use `.env.production.example`

## Testing
- `npm test` *(fails: Missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_682eefe4f7cc8328b8a75089adda83f7