### PR TITLE
Configure Netlify feed fetching

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,14 @@
   command = "npm run build"
   publish = "dist"
 
+[[plugins]]
+  package = "netlify-plugin-fetch-feeds"
+
+  [plugins.inputs]
+  feeds = [
+    { name = "hn", url = "https://hnrss.org/frontpage" }
+  ]
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "clean": "rm -rf dist",
     "replace-console-error": "ts-node scripts/replaceConsoleErrorAndImport.ts",
+    "fetch:feeds": "ts-node scripts/fetchFeeds.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/fetchFeeds.ts
+++ b/scripts/fetchFeeds.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+
+interface FeedSource {
+  name: string;
+  url: string;
+}
+
+const feeds: FeedSource[] = [
+  { name: 'hn', url: 'https://hnrss.org/frontpage' }
+];
+
+async function fetchFeed(feed: FeedSource) {
+  const { name, url } = feed;
+  if (!name || !url) {
+    console.error(`Invalid feed configuration: ${JSON.stringify(feed)}`);
+    return;
+  }
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}: ${response.status}`);
+    }
+    const text = await response.text();
+    fs.writeFileSync(`public/feeds/${name}.xml`, text);
+    console.log(`Fetched feed ${name}`);
+  } catch (err) {
+    console.error(`Error fetching feed ${name}:`, err);
+  }
+}
+
+async function run() {
+  for (const feed of feeds) {
+    await fetchFeed(feed);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- configure `netlify-plugin-fetch-feeds` in `netlify.toml`
- add a small script for manual feed fetching
- expose new script via `npm run fetch:feeds`
- add empty `public/feeds` directory

## Testing
- `npm test` *(fails: 16 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bc85fe9f08328b38df42af1c69bed