### PR TITLE
Fix Supabase policy creation syntax

### DIFF
--- a/supabase/migrations/20250611125453_nameless_field.sql
+++ b/supabase/migrations/20250611125453_nameless_field.sql
@@ -32,31 +32,66 @@ CREATE INDEX IF NOT EXISTS audio_cache_expires_at_idx ON audio_cache (expires_at
 -- Enable Row Level Security
 ALTER TABLE audio_cache ENABLE ROW LEVEL SECURITY;
 
--- Create policies for authenticated users with IF NOT EXISTS to avoid errors
-CREATE POLICY IF NOT EXISTS "Users can read their own audio cache"
-  ON audio_cache
-  FOR SELECT
-  TO authenticated
-  USING (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can read their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can read their own audio cache"
+            ON audio_cache
+            FOR SELECT
+            TO authenticated
+            USING (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can insert their own audio cache"
-  ON audio_cache
-  FOR INSERT
-  TO authenticated
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can insert their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can insert their own audio cache"
+            ON audio_cache
+            FOR INSERT
+            TO authenticated
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can update their own audio cache"
-  ON audio_cache
-  FOR UPDATE
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can update their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can update their own audio cache"
+            ON audio_cache
+            FOR UPDATE
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can delete their own audio cache"
-  ON audio_cache
-  FOR DELETE
-  TO authenticated
-  USING (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can delete their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can delete their own audio cache"
+            ON audio_cache
+            FOR DELETE
+            TO authenticated
+            USING (auth.uid() = user_id);
+    END IF;
+END$$;
 
 -- Create function to clean up expired cache entries
 CREATE OR REPLACE FUNCTION cleanup_expired_audio_cache()

--- a/supabase/migrations/20250611130000_resolve_audio_cache.sql
+++ b/supabase/migrations/20250611130000_resolve_audio_cache.sql
@@ -33,31 +33,66 @@ CREATE INDEX IF NOT EXISTS audio_cache_expires_at_idx
 -- Enable row level security
 ALTER TABLE audio_cache ENABLE ROW LEVEL SECURITY;
 
--- Policies for authenticated users
-CREATE POLICY IF NOT EXISTS "Users can read their own audio cache"
-  ON audio_cache
-  FOR SELECT
-  TO authenticated
-  USING (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can read their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can read their own audio cache"
+            ON audio_cache
+            FOR SELECT
+            TO authenticated
+            USING (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can insert their own audio cache"
-  ON audio_cache
-  FOR INSERT
-  TO authenticated
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can insert their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can insert their own audio cache"
+            ON audio_cache
+            FOR INSERT
+            TO authenticated
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can update their own audio cache"
-  ON audio_cache
-  FOR UPDATE
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can update their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can update their own audio cache"
+            ON audio_cache
+            FOR UPDATE
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can delete their own audio cache"
-  ON audio_cache
-  FOR DELETE
-  TO authenticated
-  USING (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can delete their own audio cache'
+          AND tablename = 'audio_cache'
+    ) THEN
+        CREATE POLICY "Users can delete their own audio cache"
+            ON audio_cache
+            FOR DELETE
+            TO authenticated
+            USING (auth.uid() = user_id);
+    END IF;
+END$$;
 
 -- Function to remove expired entries
 CREATE OR REPLACE FUNCTION cleanup_expired_audio_cache()

--- a/supabase/migrations/20250611140000_analytics_schema.sql
+++ b/supabase/migrations/20250611140000_analytics_schema.sql
@@ -116,60 +116,141 @@ ALTER TABLE conversion_analytics ENABLE ROW LEVEL SECURITY;
 -- ===================================
 -- Policies for authenticated users
 -- ===================================
-CREATE POLICY IF NOT EXISTS "Users can manage their analytics events"
-  ON analytics_events FOR ALL
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their analytics events'
+          AND tablename = 'analytics_events'
+    ) THEN
+        CREATE POLICY "Users can manage their analytics events"
+            ON analytics_events FOR ALL
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can manage their performance metrics"
-  ON performance_metrics FOR ALL
-  TO service_role
-  USING (true)
-  WITH CHECK (true);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their performance metrics'
+          AND tablename = 'performance_metrics'
+    ) THEN
+        CREATE POLICY "Users can manage their performance metrics"
+            ON performance_metrics FOR ALL
+            TO service_role
+            USING (true)
+            WITH CHECK (true);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can manage their error logs"
-  ON error_logs FOR ALL
-  TO service_role
-  USING (true)
-  WITH CHECK (true);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their error logs'
+          AND tablename = 'error_logs'
+    ) THEN
+        CREATE POLICY "Users can manage their error logs"
+            ON error_logs FOR ALL
+            TO service_role
+            USING (true)
+            WITH CHECK (true);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can manage their health analytics"
-  ON health_analytics FOR ALL
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their health analytics'
+          AND tablename = 'health_analytics'
+    ) THEN
+        CREATE POLICY "Users can manage their health analytics"
+            ON health_analytics FOR ALL
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can manage their supplement analytics"
-  ON supplement_analytics FOR ALL
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their supplement analytics'
+          AND tablename = 'supplement_analytics'
+    ) THEN
+        CREATE POLICY "Users can manage their supplement analytics"
+            ON supplement_analytics FOR ALL
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can manage their chat analytics"
-  ON chat_analytics FOR ALL
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their chat analytics'
+          AND tablename = 'chat_analytics'
+    ) THEN
+        CREATE POLICY "Users can manage their chat analytics"
+            ON chat_analytics FOR ALL
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can manage their goal analytics"
-  ON goal_analytics FOR ALL
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their goal analytics'
+          AND tablename = 'goal_analytics'
+    ) THEN
+        CREATE POLICY "Users can manage their goal analytics"
+            ON goal_analytics FOR ALL
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
-CREATE POLICY IF NOT EXISTS "Users can manage their conversion analytics"
-  ON conversion_analytics FOR ALL
-  TO authenticated
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'Users can manage their conversion analytics'
+          AND tablename = 'conversion_analytics'
+    ) THEN
+        CREATE POLICY "Users can manage their conversion analytics"
+            ON conversion_analytics FOR ALL
+            TO authenticated
+            USING (auth.uid() = user_id)
+            WITH CHECK (auth.uid() = user_id);
+    END IF;
+END$$;
 
 -- Service role full access
-CREATE POLICY IF NOT EXISTS "service_role_access_events"
-  ON analytics_events FOR ALL
-  TO service_role
-  USING (true)
-  WITH CHECK (true);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE policyname = 'service_role_access_events'
+          AND tablename = 'analytics_events'
+    ) THEN
+        CREATE POLICY "service_role_access_events"
+            ON analytics_events FOR ALL
+            TO service_role
+            USING (true)
+            WITH CHECK (true);
+    END IF;
+END$$;
 
 -- ===================================
 -- Materialized views


### PR DESCRIPTION
## Summary
- fix policy creation migrations for Postgres compatibility

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm test` *(fails: vitest errors and network failures)*

------
https://chatgpt.com/codex/tasks/task_e_684a492964ec8328bfab86449b01571a