### PR TITLE
Update env guidance for Supabase secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ VITE_SUPABASE_URL=your-supabase-project-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 # Optional - OpenAI API key (for local development only)
-# In production, this should be set in Supabase Edge Function secrets
+# For production, set this as a secret on your Supabase project:
+# supabase secrets set OPENAI_API_KEY=your-openai-api-key
 VITE_OPENAI_API_KEY=your-openai-api-key
 
 # Optional - For text-to-speech functionality

--- a/.env.production.example
+++ b/.env.production.example
@@ -3,6 +3,9 @@
 
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
+# Optional - OpenAI API key for production
+# Set this in your Supabase project secrets with:
+# supabase secrets set OPENAI_API_KEY=your-openai-api-key
 VITE_OPENAI_API_KEY=
 VITE_GOOGLE_CLIENT_ID=
 VITE_CAPTCHA_SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ npm install
 VITE_SUPABASE_URL=your-supabase-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 VITE_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key
+VITE_OPENAI_API_KEY=your-openai-api-key # optional for local dev
 VITE_CAPTCHA_SECRET_KEY=your-captcha-secret-key # optional
 ```
 


### PR DESCRIPTION
## Summary
- clarify how to set the OpenAI API key via Supabase secrets in env examples and README

## Testing
- `npm test` *(fails: No "CartProvider" export is defined on the mock)*

------
https://chatgpt.com/codex/tasks/task_e_68524adc98f88328ae96450c194f8200