### PR TITLE
Improve fetch error handling

### DIFF
--- a/src/api/openaiApi.ts
+++ b/src/api/openaiApi.ts
@@ -34,23 +34,29 @@ export const openaiApi = {
         throw new Error('Missing Supabase URL');
       }
       
-      const response = await fetch(
-        `${supabaseUrl}/functions/v1/openai-proxy`,
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({
-            messages,
-            context: options.context,
-            options: {
-              temperature: options.temperature,
-              max_tokens: options.max_tokens,
-              model: options.model || 'gpt-4',
-              response_format: options.response_format,
-            },
-          }),
-        }
-      );
+      let response: Response;
+      try {
+        response = await fetch(
+          `${supabaseUrl}/functions/v1/openai-proxy`,
+          {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+              messages,
+              context: options.context,
+              options: {
+                temperature: options.temperature,
+                max_tokens: options.max_tokens,
+                model: options.model || 'gpt-4',
+                response_format: options.response_format,
+              },
+            }),
+          }
+        );
+      } catch (networkError) {
+        logError('Network request failed', networkError);
+        throw new Error('Unable to reach AI service. Please check your connection.');
+      }
 
       if (!response.ok) {
         let errorData;

--- a/src/components/auth/AuthErrorHandler.tsx
+++ b/src/components/auth/AuthErrorHandler.tsx
@@ -48,10 +48,16 @@ const AuthErrorHandler = () => {
         ...init,
         credentials: 'include'
       };
-      
-      const response = await originalFetch(input, modifiedInit);
-      await handleApiResponse(response);
-      return response;
+
+      try {
+        const response = await originalFetch(input, modifiedInit);
+        await handleApiResponse(response);
+        return response;
+      } catch (error) {
+        // Log network errors for easier debugging
+        logError('Network request failed', error);
+        throw error;
+      }
     };
 
     // Cleanup function to restore original fetch


### PR DESCRIPTION
## Summary
- log network request failures in AuthErrorHandler
- catch network errors in OpenAI API proxy calls

## Testing
- `npm test` *(fails: CartProvider and ThemeProvider mocks not defined)*
- `npm run lint` *(fails: eslint config error)*

------
https://chatgpt.com/codex/tasks/task_e_6852b359b9348328b305b762e9b64866