### PR TITLE
Improve fetch error handling

### DIFF
--- a/src/components/auth/AuthErrorHandler.tsx
+++ b/src/components/auth/AuthErrorHandler.tsx
@@ -48,10 +48,16 @@ const AuthErrorHandler = () => {
         ...init,
         credentials: 'include'
       };
-      
-      const response = await originalFetch(input, modifiedInit);
-      await handleApiResponse(response);
-      return response;
+
+      try {
+        const response = await originalFetch(input, modifiedInit);
+        await handleApiResponse(response);
+        return response;
+      } catch (error) {
+        // Log network errors for easier debugging
+        logError('Network request failed', error);
+        throw error;
+      }
     };
 
     // Cleanup function to restore original fetch


### PR DESCRIPTION
## Summary
- log network request failures in AuthErrorHandler
- catch network errors in OpenAI API proxy calls
- throw ApiError for network and server failures

## Testing
- `npm test` *(fails: multiple vitest suites due to missing mocks)*
- `npm run lint` *(fails: eslint config error)*

------
https://chatgpt.com/codex/tasks/task_e_6852b359b9348328b305b762e9b64866