### PR TITLE
Add guidance for customizing Supabase Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ The `netlify.toml` file specifies a Node.js 18 environment and uses the
 `netlify-plugin-fetch-feeds` plugin to download the latest Hacker News front page 
 into `public/feeds/hn.xml` during each build.
 
+## Customizing Supabase Auth
+
+You can extend Supabase authentication using database triggers or Auth Webhooks. See [docs/customizing-supabase-auth.md](docs/customizing-supabase-auth.md) for examples of both approaches.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/docs/customizing-supabase-auth.md
+++ b/docs/customizing-supabase-auth.md
@@ -1,0 +1,71 @@
+# Customizing Supabase Auth
+
+Supabase Auth provides basic email based registration and login out of the box. You can extend its behavior using either Postgres functions or HTTP endpoints. These techniques let you add extra logic during signup or whenever a user logs in.
+
+## Using Postgres Functions
+
+Postgres functions allow you to run custom SQL whenever a user is created. In this project, the `create_profile_for_new_user` function automatically adds a row to the `profiles` table each time a new user signs up. The trigger on `auth.users` calls this function after every insert.
+
+```sql
+CREATE OR REPLACE FUNCTION public.create_profile_for_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (
+    id,
+    email,
+    created_at,
+    updated_at
+  ) VALUES (
+    NEW.id,
+    NEW.email,
+    NOW(),
+    NOW()
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS create_profile_after_signup ON auth.users;
+CREATE TRIGGER create_profile_after_signup
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.create_profile_for_new_user();
+```
+
+With this function in place, each new user automatically gets a profile record. You can modify the trigger logic to perform other tasks—such as sending a welcome email or logging analytics data—by adding more SQL inside the function.
+
+## Using HTTP Endpoints
+
+Supabase also supports Auth Webhooks. You can configure an Edge Function to receive events when users sign up. This lets you integrate with external services or run custom code outside the database.
+
+Example `supabase/functions/auth-webhook/index.ts`:
+
+```ts
+import { createClient } from "npm:@supabase/supabase-js";
+
+Deno.serve(async (req) => {
+  const payload = await req.json();
+
+  // Access the user data from the webhook
+  const { id, email } = payload.record;
+
+  // Example: store an onboarding flag in the profiles table
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+  );
+
+  await supabase
+    .from("profiles")
+    .update({ onboarding_completed: false })
+    .eq("id", id);
+
+  return new Response("ok");
+});
+```
+
+Deploy this function with `supabase functions deploy auth-webhook` and set it as an Auth Webhook in your project settings. Every signup will trigger the HTTP endpoint.
+
+---
+
+Both approaches can be combined. Postgres functions are best for quick, secure database updates, while HTTP endpoints are handy for external integrations.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -50,3 +50,5 @@ port = 54327
 verify_jwt = true
 [functions.onboarding-status]
 verify_jwt = true
+[functions.auth-webhook]
+verify_jwt = false

--- a/supabase/functions/auth-webhook/index.ts
+++ b/supabase/functions/auth-webhook/index.ts
@@ -1,0 +1,19 @@
+import { createClient } from "npm:@supabase/supabase-js";
+
+Deno.serve(async (req) => {
+  const payload = await req.json();
+
+  const { id, email } = payload.record;
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+  );
+
+  await supabase
+    .from("profiles")
+    .update({ onboarding_completed: false })
+    .eq("id", id);
+
+  return new Response("ok");
+});


### PR DESCRIPTION
## Summary
- document customizing Supabase Auth via Postgres functions and webhooks
- add example auth-webhook edge function
- reference docs in README
- register the function in `supabase/config.toml`

## Testing
- `npm test` *(fails: [vitest] No "useThemeStore" export is defined...)*

------
https://chatgpt.com/codex/tasks/task_e_68538edd51c0832894633a5c974531b7