### PR TITLE
Add simplified OpenAI proxy edge function

### DIFF
--- a/supabase/functions/openai-proxy/openai-proxy.ts
+++ b/supabase/functions/openai-proxy/openai-proxy.ts
@@ -1,0 +1,38 @@
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  apiKey: Deno.env.get("OPENAI_API_KEY"),
+});
+
+Deno.serve(async (req) => {
+  try {
+    const { messages } = await req.json();
+
+    if (!messages || !Array.isArray(messages)) {
+      return new Response(JSON.stringify({ error: "Invalid messages format" }), { status: 400 });
+    }
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4",
+      messages,
+      temperature: 0.7,
+    });
+
+    const content = completion.choices?.[0]?.message?.content;
+
+    if (!content) {
+      return new Response(JSON.stringify({ error: "No response from AI" }), { status: 502 });
+    }
+
+    return new Response(JSON.stringify({ result: content }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("Proxy error:", err);
+    return new Response(JSON.stringify({ error: "AI service failure", details: err.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a simple `openai-proxy` Supabase Edge Function using the `openai` library

## Testing
- `npm test` *(fails: No "CartProvider" export defined in mocks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853a5bc99108328b465a99b6d13d754