### PR TITLE
Add JWT secret placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ VITE_ELEVENLABS_API_KEY=your-elevenlabs-api-key
 
 # Optional - For reCAPTCHA or hCaptcha
 VITE_CAPTCHA_SECRET_KEY=your-captcha-secret-key
+
+# JWT secret used for token verification
+JWT_SECRET=your-jwt-secret
+

--- a/.env.production.example
+++ b/.env.production.example
@@ -10,3 +10,7 @@ VITE_OPENAI_API_KEY=
 VITE_GOOGLE_CLIENT_ID=
 VITE_CAPTCHA_SECRET_KEY=
 VITE_STRIPE_PUBLISHABLE_KEY=
+
+# JWT secret used for token verification
+JWT_SECRET=your-jwt-secret
+

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 VITE_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key # optional, not currently used
 VITE_OPENAI_API_KEY=your-openai-api-key # optional for local dev
 VITE_CAPTCHA_SECRET_KEY=your-captcha-secret-key # optional
+JWT_SECRET=your-jwt-secret
 ```
 
-4. For production builds, copy `.env.production.example` to `.env.production` and supply your production values (this file is ignored by Git).
+4. For production builds, copy `.env.production.example` to `.env.production` and supply your production values (this file is ignored by Git). Ensure `JWT_SECRET` is set in this file for token verification.
 
 5. Start the development server:
 


### PR DESCRIPTION
## Summary
- add placeholder for JWT secret in local and production env example files
- document JWT_SECRET usage in README

## Testing
- `npm test` *(fails: No "useThemeStore" export defined in mock)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_6853a5d26f4c832899123ef444676614