### PR TITLE
Add log for failed Supabase command attempts

### DIFF
--- a/supabase_output.txt
+++ b/supabase_output.txt
@@ -1,0 +1,4 @@
+npx supabase secrets list
+Access token not provided. Supply an access token by running supabase login or setting the SUPABASE_ACCESS_TOKEN environment variable.
+npx supabase functions deploy openai-proxy
+Access token not provided. Supply an access token by running supabase login or setting the SUPABASE_ACCESS_TOKEN environment variable.


### PR DESCRIPTION
## Summary
- log attempts to run Supabase commands without login token

## Testing
- `npx supabase secrets list` *(fails: access token not provided)*
- `npx supabase functions deploy openai-proxy` *(fails: access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_6853aab07ea8832894afe5b5d0a0e124