### PR TITLE
Update Supabase OpenAI proxy

### DIFF
--- a/supabase/functions/openai-proxy/openai-proxy.ts
+++ b/supabase/functions/openai-proxy/openai-proxy.ts
@@ -1,8 +1,13 @@
 import OpenAI from "openai";
 
-const openai = new OpenAI({
-  apiKey: Deno.env.get("OPENAI_API_KEY"),
-});
+const OPENAI_KEY = Deno.env.get("OPENAI_API_KEY");
+
+if (!OPENAI_KEY) {
+  console.error("Missing OPENAI_API_KEY in Supabase environment.");
+  throw new Error("OPENAI_API_KEY not set");
+}
+
+const openai = new OpenAI({ apiKey: OPENAI_KEY });
 
 Deno.serve(async (req) => {
   try {
@@ -30,7 +35,10 @@ Deno.serve(async (req) => {
     });
   } catch (err) {
     console.error("Proxy error:", err);
-    return new Response(JSON.stringify({ error: "AI service failure", details: err.message }), {
+    return new Response(JSON.stringify({
+      error: "AI service failure",
+      details: err instanceof Error ? err.message : "Unknown error",
+    }), {
       status: 500,
       headers: { "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- validate presence of `OPENAI_API_KEY` and provide clearer error details

## Testing
- `npm test` *(fails: No `useThemeStore` export defined on mock, ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853abf37780832891186909a96f6c54