### PR TITLE
Improve error handling for openai proxy

### DIFF
--- a/pages/api/openai-proxy.ts
+++ b/pages/api/openai-proxy.ts
@@ -2,8 +2,15 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import OpenAI from "openai";
 
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.error("OPENAI_API_KEY is missing");
+  throw new Error("OPENAI_API_KEY not configured");
+}
+
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey,
 });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -18,9 +25,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       temperature: 0.7,
     });
     res.status(200).json({ result: completion.choices[0].message.content });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
     console.error("OpenAI Proxy Error:", error);
-    res.status(500).json({ error: error.message || "Failed to fetch from OpenAI" });
+    res.status(500).json({ error: message || "Failed to fetch from OpenAI" });
   }
 }
 

--- a/supabase/functions/openai-proxy/openai-proxy.ts
+++ b/supabase/functions/openai-proxy/openai-proxy.ts
@@ -1,7 +1,14 @@
 import OpenAI from "openai";
 
+const apiKey = Deno.env.get("OPENAI_API_KEY");
+
+if (!apiKey) {
+  console.error("OPENAI_API_KEY is missing");
+  throw new Error("OPENAI_API_KEY not configured");
+}
+
 const openai = new OpenAI({
-  apiKey: Deno.env.get("OPENAI_API_KEY"),
+  apiKey,
 });
 
 Deno.serve(async (req) => {
@@ -29,10 +36,14 @@ Deno.serve(async (req) => {
       headers: { "Content-Type": "application/json" },
     });
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error("Proxy error:", err);
-    return new Response(JSON.stringify({ error: "AI service failure", details: err.message }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ error: "AI service failure", details: message }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 });


### PR DESCRIPTION
## Summary
- make openai proxy fail fast if `OPENAI_API_KEY` is missing
- add robust error handling in the Supabase function and Next.js API

## Testing
- `npm test` *(fails: No `useThemeStore` export in mock)*
- `npx -y supabase functions deploy openai-proxy` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_6853ac36938c8328a3db32b91b2e0a22