### PR TITLE
Connect chat proxy to OpenAI key

### DIFF
--- a/openaiApi.ts
+++ b/openaiApi.ts
@@ -2,9 +2,18 @@
 
 export async function createChatCompletion(messages: any) {
   try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    const apiKey = process.env.OPENAI_API_KEY || '';
+    if (apiKey) {
+      headers["x-openai-key"] = apiKey;
+    }
+
     const res = await fetch("/api/openai-proxy", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({ messages }),
     });
 


### PR DESCRIPTION
## Summary
- allow local API route to read `x-openai-key` header or query param
- include OpenAI API key header when calling the API route

## Testing
- `npm test` *(fails: No "useThemeStore" export is defined ...)*

------
https://chatgpt.com/codex/tasks/task_e_6853c65606748328be38933f979543e1