### PR TITLE
Add supplement match edge function and chat improvements

### DIFF
--- a/src/components/chat/BasicCoachChat.tsx
+++ b/src/components/chat/BasicCoachChat.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { supabase } from '../../lib/supabaseClient';
+import ReactMarkdown from 'react-markdown';
 
 interface Message {
   role: 'user' | 'coach';
@@ -9,50 +9,90 @@ interface Message {
 export default function BasicCoachChat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleSend = async () => {
     if (!input.trim()) return;
     const userMsg = { role: 'user', text: input } as Message;
     setMessages((m) => [...m, userMsg]);
+    setLoading(true);
 
-    const { data } = await supabase
-      .from('supplements')
-      .select('*')
-      .ilike('goal', `%${input}%`);
+    try {
+      const res = await fetch('/functions/v1/match_supplement', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: input }),
+      });
 
-    if (data && data.length > 0) {
-      const s = data[0];
-      const coachText = `Got it! Based on your goal, I suggest ${s.name}. ${s.evidence_summary}. [link](${s.source_link})`;
-      setMessages((m) => [...m, { role: 'coach', text: coachText }]);
-    } else {
-      setMessages((m) => [...m, { role: 'coach', text: 'No matching supplements found.' }]);
+      if (!res.ok) throw new Error('Request failed');
+
+      const data = await res.json();
+      const results = data.results as any[] | undefined;
+
+      if (results && results.length > 0) {
+        const s = results[0];
+        const coachText = `Got it! I suggest **${s.name}**. ${s.evidence_summary} [Study ↗](${s.source_link})`;
+        setMessages((m) => [...m, { role: 'coach', text: coachText }]);
+      } else {
+        setMessages((m) => [
+          ...m,
+          { role: 'coach', text: 'Hmm, I couldn\u2019t find a perfect match for that goal yet.' },
+        ]);
+      }
+    } catch (error) {
+      setMessages((m) => [
+        ...m,
+        { role: 'coach', text: 'Hmm, I couldn\u2019t find a perfect match for that goal yet.' },
+      ]);
+    } finally {
+      setLoading(false);
+      setInput('');
     }
-
-    setInput('');
   };
 
   return (
     <div className="flex h-full flex-col">
       <div className="flex-1 space-y-2 overflow-y-auto p-4">
         {messages.map((m, idx) => (
-          <div key={idx} className={m.role === 'user' ? 'text-right' : ''}>
-            <span className="inline-block rounded px-3 py-2" style={{background:m.role==='user'? '#4f46e5':'#e5e7eb', color:m.role==='user'?'#fff':'#000'}}>
-              {m.text}
-            </span>
+          <div key={idx} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+            <div
+              className={`max-w-xs rounded-lg px-3 py-2 text-sm ${
+                m.role === 'user'
+                  ? 'bg-primary text-white'
+                  : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-white'
+              }`}
+            >
+              {m.role === 'coach' ? (
+                <ReactMarkdown className="prose prose-sm break-words">
+                  {m.text}
+                </ReactMarkdown>
+              ) : (
+                <span>{m.text}</span>
+              )}
+            </div>
           </div>
         ))}
+        {loading && (
+          <div className="flex justify-start">
+            <div className="max-w-xs rounded-lg bg-gray-100 px-3 py-2 text-sm text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+              thinking...
+            </div>
+          </div>
+        )}
       </div>
       <div className="border-t p-2">
         <div className="flex gap-2">
           <input
-            className="flex-1 rounded border p-2"
+            className="flex-1 rounded-lg border p-2"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Type a message"
+            disabled={loading}
           />
           <button
-            className="rounded bg-primary px-4 py-2 text-white"
+            className="rounded-lg bg-primary px-4 py-2 text-white disabled:opacity-50"
             onClick={handleSend}
+            disabled={loading || !input.trim()}
           >
             Send
           </button>

--- a/supabase/functions/match-supplement/index.ts
+++ b/supabase/functions/match-supplement/index.ts
@@ -1,0 +1,68 @@
+import { createClient } from "npm:@supabase/supabase-js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const { query } = await req.json();
+
+    if (!query || typeof query !== "string") {
+      return new Response(JSON.stringify({ results: [] }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL") as string;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") as string;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const fields =
+      "id, name, goal, mechanism, dosage, evidence_summary, source_link";
+    const results: any[] = [];
+
+    const { data: goalMatches } = await supabase
+      .from("supplements")
+      .select(fields)
+      .ilike("goal", `%${query}%`)
+      .limit(3);
+
+    if (goalMatches) results.push(...goalMatches);
+
+    if (results.length < 3) {
+      const { data: mechMatches } = await supabase
+        .from("supplements")
+        .select(fields)
+        .ilike("mechanism", `%${query}%`)
+        .not("id", "in", `(${results.map((r) => r.id).join(",") || "null"})`)
+        .limit(3 - results.length);
+      if (mechMatches) results.push(...mechMatches);
+    }
+
+    if (results.length < 3) {
+      const { data: summaryMatches } = await supabase
+        .from("supplements")
+        .select(fields)
+        .ilike("evidence_summary", `%${query}%`)
+        .not("id", "in", `(${results.map((r) => r.id).join(",") || "null"})`)
+        .limit(3 - results.length);
+      if (summaryMatches) results.push(...summaryMatches);
+    }
+
+    return new Response(JSON.stringify({ results: results.slice(0, 3) }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("match_supplement error:", error);
+    return new Response(
+      JSON.stringify({ error: "Failed to match supplements" }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 500 },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `match_supplement` edge function to query supplements table
- update `BasicCoachChat` to call the edge function and show markdown replies

## Testing
- `npm run lint` *(fails: eslint config error)*
- `npm test` *(fails: missing Supabase env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6853d7362ae083289e0259adcc4894c7