### PR TITLE
Fix sign up and onboarding redirect

### DIFF
--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -31,7 +31,8 @@ const LoginPage = () => {
         }
         
         if (!onboardingCompleted) {
-          navigate('/quiz');
+          // Redirect new users to the onboarding flow
+          navigate('/onboarding');
           return;
         }
         
@@ -86,7 +87,8 @@ const LoginPage = () => {
       }
       
       if (!onboardingCompleted) {
-        navigate('/quiz');
+        // Send the user through onboarding before accessing the app
+        navigate('/onboarding');
         return;
       }
       

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -11,7 +11,8 @@ const SignupPage = () => {
   const { signUp } = useAuth();
   
   const handleSignupSuccess = () => {
-    navigate('/quiz');
+    // After creating an account send the user to the onboarding flow
+    navigate('/onboarding');
   };
   
   const handleSignUp = async (email: string, password: string) => {
@@ -63,7 +64,7 @@ const SignupPage = () => {
         )}
         
         <div className="rounded-xl bg-[hsl(var(--color-card))] p-8 shadow-lg dark:shadow-lg dark:shadow-black/10">
-          <SignUpForm onSuccess={handleSignupSuccess} onSignUp={handleSignUp} redirectTo="/quiz" />
+          <SignUpForm onSuccess={handleSignupSuccess} onSignUp={handleSignUp} redirectTo="/onboarding" />
         </div>
         
         <div className="mt-6 text-center text-sm text-text-light">


### PR DESCRIPTION
## Summary
- send new users to the onboarding page after signup
- route existing users without onboarding completion to the onboarding page when logging in

## Testing
- `npm test` *(fails: Missing Supabase URL configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685587aace848328b7f44b1d82b02a71