### PR TITLE
Add recommendation edge function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ dist-ssr
 
 # Temporary files
 /tmp
-/temp
+/tempdeno.lock

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -29,3 +29,7 @@ verify_jwt = false
 
 [functions.onboarding-status]
 verify_jwt = false
+
+[functions.recommendations]
+verify_jwt = false
+

--- a/supabase/functions/recommendations/index.test.ts
+++ b/supabase/functions/recommendations/index.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from 'https://deno.land/std@0.168.0/testing/asserts.ts';
+import { stub } from 'https://deno.land/std@0.168.0/testing/mock.ts';
+
+Deno.test({ name: 'handler returns recommendation from OpenAI', sanitizeOps: false, sanitizeResources: false }, async () => {
+  // Stub Supabase createClient
+  const metrics = {
+    sleep_hours: 7,
+    deep_sleep_minutes: 90,
+    daily_steps: 8000,
+    calories_burned: 2100,
+    bmi: 23,
+    activity_goal: 'maintenance'
+  };
+  const supabaseData = metrics;
+
+  // Stub fetch for OpenAI
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('api.openai.com')) {
+      return Promise.resolve(new Response(
+        JSON.stringify({ choices: [{ message: { content: 'do more exercise' } }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      ));
+    }
+    // supabase metrics request
+    return Promise.resolve(new Response(
+      JSON.stringify(supabaseData),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    ));
+  }) as typeof fetch;
+
+  const { handler } = await import('./index.ts');
+
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ userId: '1', userQuestion: 'how to improve health?' })
+  });
+
+  const res = await handler(req);
+  const body = await res.json();
+
+  assertEquals(body.reply, 'do more exercise');
+
+  globalThis.fetch = originalFetch;
+});

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -1,0 +1,57 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const openaiApiKey = Deno.env.get('OPENAI_API_KEY')!;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export async function handler(req: Request): Promise<Response> {
+  const { userId, userQuestion } = await req.json();
+
+  const { data: userMetrics, error } = await supabase
+    .from('user_metrics')
+    .select('*')
+    .eq('user_id', userId)
+    .single();
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 400 });
+  }
+
+  const prompt = `
+  User metrics:
+  - Sleep hours: ${userMetrics.sleep_hours}
+  - Deep sleep: ${userMetrics.deep_sleep_minutes} minutes
+  - Daily steps: ${userMetrics.daily_steps}
+  - Calories burned: ${userMetrics.calories_burned}
+  - BMI: ${userMetrics.bmi}
+  - Activity goal: ${userMetrics.activity_goal}
+
+  User question: "${userQuestion}"
+
+  Provide clear, actionable, personalized recommendations based on the provided metrics.
+  `;
+
+  const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${openaiApiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 300,
+    }),
+  });
+
+  const gptData = await openaiResponse.json();
+
+  return new Response(JSON.stringify({ reply: gptData.choices[0].message.content }), { status: 200 });
+}
+
+if (import.meta.main) {
+  serve(handler);
+}


### PR DESCRIPTION
## Summary
- add new `recommendations` edge function for personalized health tips
- configure the function in `supabase/config.toml`
- include Deno test with stubbed fetch
- ignore Deno lock files

## Testing
- `npm test` *(fails: CartProvider and other mocks missing)*
- `deno test --allow-env --no-check supabase/functions/recommendations/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_685cba1c0d98832898a8d76b4d43f70c