### PR TITLE
Fix VoicePreferences import path

### DIFF
--- a/src/pages/chat/ChatPage.tsx
+++ b/src/pages/chat/ChatPage.tsx
@@ -108,7 +108,7 @@ import AIHealthCoach from '../../components/chat/AIHealthCoach';
 import { MessageCircle, Zap, History, Settings, Volume2, VolumeX } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useChatStore } from '../../store';
-import VoicePreferences from '../components/chat/VoicePreferences';
+import VoicePreferences from '../../components/chat/VoicePreferences';
 
 const ChatPage = () => {
   const [activeTab, setActiveTab] = useState('chat');


### PR DESCRIPTION
## Summary
- correct relative import path for VoicePreferences in `ChatPage.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm test` *(fails: 16 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_685cc4f99e0c832881c02242560f2ebb