### PR TITLE
Add shopping cart database and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Biowell AI is a digital health platform that connects your wearable devices, del
 - **Onboarding Quiz**: Detailed health assessment to personalize your experience
 - **Wearable Integration**: Connect with Apple Health, Oura Ring, Garmin, and more
 - **Subscription Management**: Subscribe to recommended supplements for monthly delivery
+- **Shopping Cart**: Save supplements in your cart with quantity tracking
 
 > **Disclaimer**: Biowell AI does not provide medical diagnosis or treatment. The AI coach offers general wellness guidance based on the information you share. Always consult a qualified healthcare professional for medical concerns.
 

--- a/src/api/cartApi.ts
+++ b/src/api/cartApi.ts
@@ -1,0 +1,66 @@
+import { apiClient } from './apiClient';
+import { supabase } from '../lib/supabaseClient';
+import type { CartItem } from '../store/useCartStore';
+
+export const cartApi = {
+  async getCart(userId: string): Promise<CartItem[]> {
+    return apiClient.request(
+      () =>
+        supabase
+          .from('cart_items')
+          .select('id, supplement_id, quantity, supplements(*)')
+          .eq('user_id', userId),
+      'Failed to fetch cart items'
+    ).then(rows =>
+      rows.map(r => ({
+        id: r.supplement_id,
+        name: r.supplements.name,
+        price: r.supplements.price_aed || r.supplements.price || 0,
+        quantity: r.quantity,
+        image: r.supplements.form_image_url || r.supplements.image_url || '',
+        description: r.supplements.description || ''
+      }))
+    );
+  },
+
+  async addItem(userId: string, supplementId: string, quantity = 1): Promise<void> {
+    await apiClient.request(
+      () =>
+        supabase
+          .from('cart_items')
+          .upsert({ user_id: userId, supplement_id: supplementId, quantity }, { onConflict: 'user_id,supplement_id' }),
+      'Failed to add item to cart'
+    );
+  },
+
+  async updateQuantity(userId: string, supplementId: string, quantity: number): Promise<void> {
+    await apiClient.request(
+      () =>
+        supabase
+          .from('cart_items')
+          .update({ quantity })
+          .eq('user_id', userId)
+          .eq('supplement_id', supplementId),
+      'Failed to update cart item'
+    );
+  },
+
+  async removeItem(userId: string, supplementId: string): Promise<void> {
+    await apiClient.request(
+      () =>
+        supabase
+          .from('cart_items')
+          .delete()
+          .eq('user_id', userId)
+          .eq('supplement_id', supplementId),
+      'Failed to remove cart item'
+    );
+  },
+
+  async clearCart(userId: string): Promise<void> {
+    await apiClient.request(
+      () => supabase.from('cart_items').delete().eq('user_id', userId),
+      'Failed to clear cart'
+    );
+  }
+};

--- a/supabase/migrations/20250628120000_shopping_cart.sql
+++ b/supabase/migrations/20250628120000_shopping_cart.sql
@@ -1,0 +1,47 @@
+/*
+  # Shopping Cart Table
+
+  1. New Tables
+    - cart_items: Records supplements a user has added to their shopping cart
+
+  2. Indexes
+    - Unique index on user_id and supplement_id to prevent duplicates
+
+  3. Security
+    - Row level security with policies so users manage only their own cart items
+*/
+
+-- Create cart_items table
+CREATE TABLE IF NOT EXISTS cart_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  supplement_id uuid NOT NULL REFERENCES supplements(id) ON DELETE CASCADE,
+  quantity integer NOT NULL DEFAULT 1,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz
+);
+
+-- Unique index for quick lookups
+CREATE UNIQUE INDEX IF NOT EXISTS cart_items_user_supplement_idx
+  ON cart_items(user_id, supplement_id);
+
+-- Enable row level security
+ALTER TABLE cart_items ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Users can view their own cart items"
+  ON cart_items FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert cart items"
+  ON cart_items FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own cart items"
+  ON cart_items FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own cart items"
+  ON cart_items FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `cart_items` table and policies
- expose cart management in new `cartApi`
- document the shopping cart feature in README

## Testing
- `npm test` *(fails: 17 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685e6bdf01a083288e41f399a008775f