### PR TITLE
Update README with testing prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ npm run dev
 
 ### Running Tests and Lint
 
-Make sure to install dependencies before running any tests or lint checks:
+1. **Install dependencies** (required before running `npm test`):
+   ```bash
+   npm install
+   ```
+2. **Run lint and tests**:
+   ```bash
+   npm run lint
+   npm test
+   ```
 
-```bash
-npm install
-```
-
-Then run:
-
-```bash
-npm run lint
-npm test
-```
+You can also use the convenience script `scripts/setup.sh` to install
+dependencies automatically before running tests locally.
 
 ### Supabase Setup
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Simple setup script for local development.
+# Installs dependencies and runs tests.
+
+set -e
+
+npm install
+npm test


### PR DESCRIPTION
## Summary
- emphasize that `npm install` must run before `npm test`
- add optional `scripts/setup.sh` convenience script for local testing

## Testing
- `npm test` *(fails: Cannot reach OpenAI API and other tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_685f4f4f16d48328a4c35bcbc3515a0a