### PR TITLE
Add ErrorBoundary for StackBuilder

### DIFF
--- a/src/components/common/ErrorBoundary.test.tsx
+++ b/src/components/common/ErrorBoundary.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ErrorBoundary from './ErrorBoundary';
+
+function ProblemChild() {
+  throw new Error('Test error');
+}
+
+describe('ErrorBoundary', () => {
+  it('should render fallback when an error is thrown', () => {
+    const fallbackText = 'Fallback UI';
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary fallback={<div>{fallbackText}</div>}>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText(fallbackText)).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('should render children when no error occurs', () => {
+    // Arrange & Act
+    render(
+      <ErrorBoundary>
+        <div>Child</div>
+      </ErrorBoundary>
+    );
+
+    // Assert
+    expect(screen.getByText('Child')).toBeInTheDocument();
+  });
+});

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Simple error boundary to catch React rendering errors
+ */
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || <div>Something went wrong.</div>;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/pages/supplements/SupplementsPage.tsx
+++ b/src/pages/supplements/SupplementsPage.tsx
@@ -12,6 +12,7 @@ import SupplementCategories from '../../components/supplements/SupplementCategor
 import SupplementFeatured from '../../components/supplements/SupplementFeatured';
 import StackBuilder from '../../components/supplements/StackBuilder';
 import SupplementRecommender from '../../components/supplements/SupplementRecommender';
+import ErrorBoundary from '../../components/common/ErrorBoundary';
 
 const SupplementsPage = () => {
   const { user } = useAuthStore();
@@ -200,11 +201,14 @@ const SupplementsPage = () => {
                     </TabsContent>
                     
                     <TabsContent value="stacks" className="mt-0">
-                      <StackBuilder 
-                        supplements={supplements}
-                        userSupplements={userSupplements}
-                        onToggleSubscription={(supplementId) => toggleSubscription(user?.id || '', supplementId)}
-                      />
+                      <ErrorBoundary>
+                        <StackBuilder
+                          supplements={supplements}
+                          userSupplements={userSupplements}
+                          onToggleSubscription={(supplementId) =>
+                            toggleSubscription(user?.id || '', supplementId)}
+                        />
+                      </ErrorBoundary>
                     </TabsContent>
                     
                     <TabsContent value="recommend" className="mt-0">


### PR DESCRIPTION
## Summary
- add a reusable `ErrorBoundary` component
- test error boundary behavior
- wrap `StackBuilder` in `SupplementsPage` with the new error boundary

## Testing
- `npm test` *(fails: network errors and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6864e5008cc48328a9467b7300ea1903