### PR TITLE
Fix stray CSS tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-backup-before-consolidation
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -476,4 +475,3 @@ body {
     @apply min-h-[44px] min-w-[44px] flex items-center justify-center sm:justify-start;
   }
 }
- main


### PR DESCRIPTION
## Summary
- clean up `src/index.css` by removing stray tokens that broke parsing

## Testing
- `npm run lint` *(fails: 235 problems)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac922d29483288ab9e226f8443dd4